### PR TITLE
Add support for different networks

### DIFF
--- a/src/hooks/useRewards.tsx
+++ b/src/hooks/useRewards.tsx
@@ -20,7 +20,7 @@ export const useRewards = (): UseRewardsType => {
         React.useContext(ImpactMarketContext);
 
     const getEstimatedClaimableRewards = async () => {
-        if (!donationMiner?.provider) {
+        if (!donationMiner?.provider || !address) {
             return;
         }
 
@@ -42,7 +42,7 @@ export const useRewards = (): UseRewardsType => {
     };
 
     const getClaimableRewards = async () => {
-        if (!donationMiner?.provider) {
+        if (!donationMiner?.provider || !address) {
             return;
         }
 


### PR DESCRIPTION
Add support for different networks avoiding some methods to run if the network is not the same.
For context, focus on the changes in the `example/App.tsx`.