### PR TITLE
JsonRpcProvider to StaticJsonRpcProvider

### DIFF
--- a/example-web/pages/components/PACTMetrics/index.tsx
+++ b/example-web/pages/components/PACTMetrics/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import { getPACTTradingMetrics, getPACTTVL, getUBILiquidity } from '@impact-market/utils/pact';
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Mainnet } from '@celo/react-celo';
 
 const PACTMetrics = () => {
@@ -24,10 +24,11 @@ const PACTMetrics = () => {
 
     useEffect(() => {
         const loadPactPriceVolumeLiquidity = async () => {
-            const provider = new JsonRpcProvider(Mainnet.rpcUrl);
-            const r = await getPACTTradingMetrics(provider);
-            const tvl = await getPACTTVL(provider);
-            const ubiLiquidity = await getUBILiquidity(provider);
+            const provider = new StaticJsonRpcProvider(Mainnet.rpcUrl);
+            const { chainId } = await provider.getNetwork();
+            const r = await getPACTTradingMetrics(chainId);
+            const tvl = await getPACTTVL(provider, chainId);
+            const ubiLiquidity = await getUBILiquidity(provider, chainId);
             setPactTradingMetrics({ ...r, tvl: parseInt(tvl, 10), ubiLiquidity });
         };
         loadPactPriceVolumeLiquidity();

--- a/example-web/pages/index.tsx
+++ b/example-web/pages/index.tsx
@@ -4,7 +4,7 @@ import WalletsBalance from './components/WalletsBalance';
 import DaoBreakdown from './components/DaoBreakdown';
 import DaoHooks from './components/DaoHooks';
 import { Alfajores, useCelo, useProviderOrSigner } from '@celo/react-celo';
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import PACTMetrics from './components/PACTMetrics';
 import Community from './components/Community';
 import Staking from './components/Staking';
@@ -33,7 +33,7 @@ const initialOption = options[9];
 
 const network = Alfajores;
 
-const provider = new JsonRpcProvider(network.rpcUrl);
+const provider = new StaticJsonRpcProvider(network.rpcUrl);
 function App() {
     const signer = useProviderOrSigner();
     // const provider = useProvider();

--- a/src/ImpactProvider.tsx
+++ b/src/ImpactProvider.tsx
@@ -1,5 +1,5 @@
 import { ApolloCache } from '@apollo/client/cache/core/cache';
-import { BaseProvider, JsonRpcProvider } from '@ethersproject/providers';
+import { BaseProvider, StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Connection } from '@celo/connect';
 import { ImpactMarketSubgraph, ImpactMarketUBIManagementSubgraph } from './subgraphs';
 import { NormalizedCacheObject } from '@apollo/client/cache/inmemory/types';
@@ -252,7 +252,7 @@ export const ImpactProvider = (props: ProviderProps) => {
                 connection,
                 defaultFeeCurrency,
                 networkId,
-                provider: new JsonRpcProvider(jsonRpc),
+                provider: new StaticJsonRpcProvider(jsonRpc),
                 subgraph: new ImpactMarketSubgraph(networkId, apolloClientOptions),
                 ubiManagementSubgraph: new ImpactMarketUBIManagementSubgraph(connection, networkId, apolloClientOptions)
             }}


### PR DESCRIPTION
JsonRpcProvider is doing too many requests to get chainId, but chainId never changes.
Avoiding all those requests would save a lot on the RPC plan.

More details here https://docs.ethers.org/v5/api/providers/jsonrpc-provider/#StaticJsonRpcProvider

And request details
<img width="835" alt="image" src="https://user-images.githubusercontent.com/19441097/213746008-41514332-aad8-4c23-919d-f639367fac45.png">
